### PR TITLE
Add multi-arch (amd64 + arm64) release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,28 @@ env:
   PACKAGE: "influxdb3"
   PBS_DATE: "unset"
   PBS_VERSION: "unset"
-  PBS_TARGET: "x86_64-unknown-linux-gnu"
+  IMAGE: "ghcr.io/metrico/influxdb3-unlocked"
 
 jobs:
   build-binary:
-    name: Build Binary
-    runs-on: ubuntu-latest
+    name: Build Binary (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            asset: influxdb3
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset: influxdb3-arm64
     outputs:
-      version: ${{ env.VERSION }}
+      version: ${{ steps.version.outputs.version }}
+    env:
+      PBS_TARGET: ${{ matrix.target }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,9 +56,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-
 
       - name: Install dependencies
         run: |
@@ -57,21 +71,22 @@ jobs:
           objcopy --compress-debug-sections "target/$PROFILE/$PACKAGE"
 
       - name: Extract version
+        id: version
         run: |
           VERSION=$(./target/$PROFILE/$PACKAGE --version | cut -d' ' -f2 | cut -d',' -f1)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
       - name: Create release archive
         run: |
           mkdir -p release
-          cp "./target/$PROFILE/$PACKAGE" release/influxdb3
+          cp "./target/$PROFILE/$PACKAGE" "release/${{ matrix.asset }}"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: influxdb3
-          path: ./release/influxdb3
+          name: influxdb3-${{ matrix.arch }}
+          path: ./release/${{ matrix.asset }}
           retention-days: 1
 
       - name: Release
@@ -79,12 +94,27 @@ jobs:
         if: github.ref_type == 'tag'
         with:
           files: |
-            ./release/influxdb3
-            
+            ./release/${{ matrix.asset }}
+
   build-docker:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+    name: Build Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     needs: build-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: linux/amd64
+            asset: influxdb3
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            asset: influxdb3-arm64
+    outputs:
+      digest-amd64: ${{ steps.collect.outputs.digest-amd64 }}
+      digest-arm64: ${{ steps.collect.outputs.digest-arm64 }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -95,8 +125,14 @@ jobs:
       - name: Download binary artifact
         uses: actions/download-artifact@v4
         with:
-          name: influxdb3
-          path: ./binary
+          name: influxdb3-${{ matrix.arch }}
+          path: ./binary-tmp
+
+      - name: Stage binary for Dockerfile
+        run: |
+          mkdir -p ./binary
+          mv "./binary-tmp/${{ matrix.asset }}" ./binary/influxdb3
+          chmod +x ./binary/influxdb3
 
       - name: Log in to the GHCR registry
         uses: docker/login-action@v3.4.0
@@ -108,16 +144,65 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
 
-      - name: Docker Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6.18.0
         with:
           context: .
           file: ./docker/Dockerfile.prebuilt
-          push: true
-          tags: |
-            ghcr.io/metrico/influxdb3-unlocked:latest
-            ghcr.io/metrico/influxdb3-unlocked:${{ needs.build-binary.outputs.version }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             PACKAGE=influxdb3
-          cache-from: type=gha
-          cache-to: type=gha,mode=max 
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-docker-manifest:
+    name: Merge Docker Manifest
+    runs-on: ubuntu-latest
+    needs:
+      - build-binary
+      - build-docker
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to the GHCR registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${{ needs.build-binary.outputs.version }}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${IMAGE}:${{ needs.build-binary.outputs.version }}"


### PR DESCRIPTION
Closes #5

Build binary and Docker image on both amd64 and arm64 runners in parallel, then merge per-arch image digests into a single multi-arch manifest under the existing image tags. Adds an arm64 release asset (influxdb3-arm64) alongside the existing amd64 asset (influxdb3).